### PR TITLE
Fix wrong import in adapter factory

### DIFF
--- a/clio_sdk/adapter_factory/base.py
+++ b/clio_sdk/adapter_factory/base.py
@@ -1,7 +1,7 @@
 # adapter_factory/base.py
 from typing import Callable, Dict, Type
 
-from adapter_factory.transformer import get_transformer
+from .transformer import get_transformer
 from pydantic import BaseModel
 from clio_sdk.adapter_factory.i_adapter_factory import IAdapterFactory
 


### PR DESCRIPTION
## Summary
- fix relative import for transformer helper in adapter factory

## Testing
- `pytest tests/test_adapters/test_activity_adapter.py::test_roundtrip_activity_variants -q` *(fails: ModuleNotFoundError: No module named 'clio_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_68421176a3fc8331a9e06f0ea043d617